### PR TITLE
Add working validation tests for Ingredient model boolean values

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,7 +4,6 @@ class Ingredient < ApplicationRecord
 
   validates :name, presence: true
   validates :national_price, numericality: { greater_than: 0, only_float: true }
-  # I'm pretty sure this is the correct way to validate these last two ingredient attributes.
-  # validates :taxable, inclusion: { in: [true, false] }
-  # validates :snap, inclusion: { in: [true, false] }
+  validates :taxable, inclusion: { in: [true, false] }
+  validates :snap, inclusion: { in: [true, false] }
 end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -9,7 +9,31 @@ RSpec.describe Ingredient, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_numericality_of(:national_price).is_greater_than(0) }
-    # it { should validate_inclusion_of(:taxable).in_array([true, false]) }
-    # it { should validate_inclusion_of(:snap).in_array([true, false]) }
+  end
+
+  context "validating boolean values" do
+    it 'validates taxable to be either true or false' do
+      ingredient_true = Ingredient.new(name: "test_taxable", national_price: 10, taxable: true, snap: true)
+      ingredient_false = Ingredient.new(name: "test_taxable", national_price: 10, taxable: false, snap: true)
+      
+      ingredient_nil = Ingredient.new(name: "test_taxable", national_price: 10, taxable: nil, snap: true)
+      
+      expect(ingredient_true).to be_valid
+      expect(ingredient_false).to be_valid
+      expect(ingredient_nil).not_to be_valid
+      expect(ingredient_nil.errors[:taxable]).to include("is not included in the list")
+    end
+
+    it 'validates snap to be either true or false' do
+      ingredient_true = Ingredient.new(name: "test_snap", national_price: 10, taxable: true, snap: true)
+      ingredient_false = Ingredient.new(name: "test_snap", national_price: 10, taxable: true, snap: false)
+      
+      ingredient_nil = Ingredient.new(name: "test_snap", national_price: 10, taxable: true, snap: nil)
+      
+      expect(ingredient_true).to be_valid
+      expect(ingredient_false).to be_valid
+      expect(ingredient_nil).not_to be_valid
+      expect(ingredient_nil.errors[:snap]).to include("is not included in the list")
+    end
   end
 end


### PR DESCRIPTION
This PR finalizes the validation tests for the Ingredient model to include the previously missing boolean tests by writing tests which do NOT use shoulda-matchers.  Valid Ingredient attributes (taxable & snap) are now restricted to hold only true or false values and never nil.